### PR TITLE
release: v2.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "confluence-updater"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "clap",
  "comrak",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "derive_more",
  "hex",
  "normalize-path",
+ "regex",
  "reqwest",
  "serde",
  "serde_yml",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ sha2 = "0.10.8"
 hex = "0.4.3"
 normalize-path = "0.2.1"
 derive_more = { version = "2.0.1", features = ["debug"] }
+regex = "1.11.1"
 
 [profile.release]
 lto = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confluence-updater"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2021"
 description = "Render Markdown files and push them to Confluence Cloud pages."
 authors = ["Patrick Kerwood <patrick@kerwood.dk>"]

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ A GitHub Action is available: [Confluence Updater Action](https://github.com/Ker
 - Changed the `pa-token:xxx` and `page-sha:xxx` labels to use supported characters. (`pa-token/xxx`, `page-sha/xxx`)
 - Added a regex check to all labels. If labes are not valid they will be skipped and a warning will be emitted.
 - Added better error logs if FQDN is missing `https://` protocol scheme.
+- Confluence updater now uploads page images before it updates the page.
 
 ### 2.1.0
 - Added support for superscript page header. See [Superscript Header](#superscript-header)

--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ A GitHub Action is available: [Confluence Updater Action](https://github.com/Ker
 ### 2.1.1
 - Changed the `pa-token:xxx` and `page-sha:xxx` labels to use supported characters. (`pa-token/xxx`, `page-sha/xxx`)
 - Added a regex check to all labels. If labes are not valid they will be skipped and a warning will be emitted.
+- Added better error logs if FQDN is missing `https://` protocol scheme.
 
 ### 2.1.0
 - Added support for superscript page header. See [Superscript Header](#superscript-header)

--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ You can control image alignment by specifying `align-left`, `align-right`, or `a
 ![align-center](./images/bender.png)
 ```
 
+**NOTE:** The Confluence API is a bit unstable when it comes to uploading attachments.
+The is also the reason that images are not uploaded asynchronously. Some times you will recieve below error for no apparent reason.
+```
+ERROR image="images/superscriptheader.png" error=HTTP request, HTTP status server error (500 Internal Server Error)
+```
+
 ### Superscript Header
 Add a small superscript header with Markdown support at the top of each page by setting `superscriptHeader` at the root or page level:
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Confluence Cloud requires personal access tokens for authentication.
 
 Generate an API token at: [Atlassian API Tokens.](https://id.atlassian.com/manage-profile/security/api-tokens)
 
-The tool applies a label using the local part of the email associated with the token. For example, `patrick@kerwood.dk` will have the label `pa-token:patrick` applied. This labeling system helps track and replace tokens when necessary.
+The tool applies a label using the local part of the email associated with the token. For example, `patrick@kerwood.dk` will have the label `pa-token/patrick` applied. This labeling system helps track and replace tokens when necessary.
 
 By setting the `superscriptHeader` property in the configuration, you can quickly locate Confluence pages linked to a specific repository.
 
@@ -150,6 +150,10 @@ A GitHub Action is available: [Confluence Updater Action](https://github.com/Ker
 ```
 
 ## Release Notes
+
+### 2.1.1
+- Changed the `pa-token:xxx` and `page-sha:xxx` labels to use supported characters. (`pa-token/xxx`, `page-sha/xxx`)
+- Added a regex check to all labels. If labes are not valid they will be skipped and a warning will be emitted.
 
 ### 2.1.0
 - Added support for superscript page header. See [Superscript Header](#superscript-header)

--- a/confluence-updater.yaml
+++ b/confluence-updater.yaml
@@ -1,13 +1,13 @@
-superscriptHeader: This page is sourced from [kerwood/confluence-updater](https://github.com/Kerwood/confluence-updater)
-readOnly: true # Default
+superscriptHeader: This page is sourced from [kerwood/confluence-updater](https://github.com/Kerwood/confluence-updater) # Optional
+readOnly: true # Default. Optional
 pages:
   - filePath: ./path/to/markdown-1.md
     pageId: 353468432
-    overrideTitle: Some Other Title
-    superscriptHeader: Some other superscript header # This will override the global superscriptHeader property.
-    readOnly: false # This will override the global readOnly property.
-    labels:
-      - ci/cd
+    overrideTitle: Some Other Title # Optional
+    superscriptHeader: Some other superscript header # Optional. This will override the global superscriptHeader property.
+    readOnly: false # Optional. This will override the global readOnly property.
+    labels: # Optional
+      - ci/cd 
 
   - filePath: ./path/to/markdown-2.md
     pageId: 353435649

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,4 @@
+use crate::confluence;
 use crate::error::{Error, Result};
 use crate::render_markdown::HtmlPage;
 use crate::CommandArgs;
@@ -158,9 +159,10 @@ impl Config {
                 page_config.labels = Some(vec![]);
             }
 
-            // Add global cli labels to the page config.
+            // Add global cli labels to the page config and filter our invalid labels.
             if let Some(ref mut vec) = page_config.labels {
-                vec.extend(args.labels.iter().cloned())
+                vec.extend(args.labels.iter().cloned());
+                *vec = confluence::filter_valid_labels(vec);
             }
 
             // Set default read_only to true or overwrite read_only if it's set globally and not explicitly on the page.

--- a/src/confluence/client.rs
+++ b/src/confluence/client.rs
@@ -55,10 +55,16 @@ pub struct ConfluenceClient {
 }
 
 impl ConfluenceClient {
-    #[instrument(skip_all, err(Debug, level = Level::DEBUG))]
+    #[instrument(skip_all, name = "confluence_client::new" err(Debug, level = Level::DEBUG))]
     pub fn new(fqdn: &str, user: &str, secret: &str) -> Result<Self> {
         let client = ClientBuilder::new().build()?;
         let base_url = fqdn.to_string();
+
+        if !base_url.starts_with("https://") {
+            let error = Error::HttpsProtocolSchemeMissing(base_url);
+            error!(%error);
+            return Err(error);
+        }
 
         debug!(%base_url, "creating confluence client");
 

--- a/src/confluence/client.rs
+++ b/src/confluence/client.rs
@@ -174,8 +174,8 @@ impl ConfluenceClient {
             Some(labels) => labels
                 .results
                 .iter()
-                .filter(|x| x.name.starts_with("page-sha:"))
-                .map(|x| x.name.split("page-sha:").collect::<String>())
+                .filter(|x| x.name.starts_with("page-sha/"))
+                .map(|x| x.name.split("page-sha/").collect::<String>())
                 .collect(),
             None => String::new(),
         };
@@ -214,8 +214,8 @@ impl ConfluenceClient {
             .to_string();
 
         let labels = vec![
-            format!("page-sha:{}", page.page_sha),
-            format!("pa-token:{}", user_label),
+            format!("page-sha/{}", page.page_sha),
+            format!("pa-token/{}", user_label),
         ];
 
         let confluence_page = ConfluencePage::new(page, version).add_labels(labels);

--- a/src/confluence/mod.rs
+++ b/src/confluence/mod.rs
@@ -2,4 +2,4 @@ mod client;
 mod page;
 mod restriction;
 pub use client::ConfluenceClient;
-pub use page::ConfluencePage;
+pub use page::{filter_valid_labels, ConfluencePage};

--- a/src/error.rs
+++ b/src/error.rs
@@ -21,8 +21,8 @@ pub enum Error {
     )]
     PageHeaderMissing,
 
-    #[error("Protocol scheme is missing from FQDN: [{0}]")]
-    ProtocolSchemeMissing(String),
+    #[error("HTTPS protocol scheme missing from FQDN: [{0}]")]
+    HttpsProtocolSchemeMissing(String),
 
     #[error("File path is invalid: [{0}]")]
     InvalidFilePath(String),

--- a/src/error.rs
+++ b/src/error.rs
@@ -29,12 +29,6 @@ pub enum Error {
 
     #[error("Failed to get the local part of the current user email.")]
     CurrentUserEmailMissing,
-
-    #[error("The link/path for image is missing")]
-    ImageLinkMissing,
-
-    #[error("A confluence page ID annotation was found on a link, but could not be parsed [{0}]")]
-    LinkIdMissing(String),
 }
 
 pub type Result<T, E = Error> = std::result::Result<T, E>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -108,7 +108,7 @@ async fn main() {
 
     let client = match ConfluenceClient::new(fqdn, user, secret) {
         Ok(client) => client,
-        Err(_error) => std::process::exit(1),
+        Err(_) => std::process::exit(1),
     };
 
     for page in config.pages.iter() {

--- a/src/render_markdown.rs
+++ b/src/render_markdown.rs
@@ -8,7 +8,6 @@ use comrak::{
 use normalize_path::NormalizePath;
 use serde::Deserialize;
 use std::{cell::RefCell, collections::HashSet, path::Path};
-use tracing::{debug, warn};
 use tracing::{debug, instrument, warn, Level};
 
 type NodeRef<'a> = &'a Node<'a, RefCell<Ast>>;
@@ -66,11 +65,11 @@ impl HtmlPage {
         options.extension.superscript = true;
 
         let root_node = parse_document(&arena, &md_file, &options);
-        let title = get_h1_header(root_node);
 
-        remove_h1_header(root_node);
-        replace_codeblock_with_html(root_node);
+        let title = get_and_remove_h1_header(root_node);
         let image_paths = get_image_paths(root_node, &page_config.file_path);
+
+        replace_codeblock_with_html(root_node);
         replace_image_node_with_html(root_node);
         replace_page_link(root_node).await?;
 
@@ -140,19 +139,8 @@ fn get_image_paths(root_node: NodeRef<'_>, md_file_path: &str) -> Vec<String> {
         .collect::<Vec<String>>()
 }
 
-// Removes the very first child of the AST if it is a h1 header.
-fn remove_h1_header(root_node: NodeRef<'_>) {
-    if let Some(node) = root_node.first_child() {
-        if let NodeValue::Heading(header) = node.data.borrow().value {
-            if header.level == 1 {
-                debug!("first child of root node is h1, detaching node.");
-                node.detach();
-            }
-        }
-    }
-}
-// TODO: May this could be one function.
-fn get_h1_header(root_node: NodeRef<'_>) -> Option<String> {
+// Retrieves the NodeValue::Text if the first child is a h1 header, and then removes it.
+fn get_and_remove_h1_header(root_node: NodeRef<'_>) -> Option<String> {
     let first_child = root_node.first_child()?;
     let child_value = &first_child.data.borrow().value;
 
@@ -167,6 +155,9 @@ fn get_h1_header(root_node: NodeRef<'_>) -> Option<String> {
             title.push_str(text);
         }
     }
+
+    debug!("first child of root node is h1, detaching node.");
+    first_child.detach();
 
     Some(title)
 }

--- a/src/render_markdown.rs
+++ b/src/render_markdown.rs
@@ -9,6 +9,7 @@ use normalize_path::NormalizePath;
 use serde::Deserialize;
 use std::{cell::RefCell, collections::HashSet, path::Path};
 use tracing::{debug, warn};
+use tracing::{debug, instrument, warn, Level};
 
 type NodeRef<'a> = &'a Node<'a, RefCell<Ast>>;
 
@@ -56,7 +57,7 @@ pub struct HtmlPage {
 }
 
 impl HtmlPage {
-    // TODO: Instrument maybe ?
+    #[instrument(skip_all, ret(level = Level::TRACE), err(Debug, level = Level::DEBUG))]
     pub async fn new(page_config: &PageConfig) -> Result<HtmlPage> {
         let md_file = std::fs::read_to_string(&page_config.file_path)?;
         let arena = Arena::new();


### PR DESCRIPTION
- Changed the `pa-token:xxx` and `page-sha:xxx` labels to use supported characters. (`pa-token/xxx`, `page-sha/xxx`)
- Added a regex check to all labels. If labes are not valid they will be skipped and a warning will be emitted.
- Added better error logs if FQDN is missing `https://` protocol scheme.
- Confluence updater now uploads page images before it updates the page.
