### PR TITLE
release: v2.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -282,9 +282,9 @@ checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "comrak"
-version = "0.35.0"
+version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52602e10393cfaaf8accaf707f2da743dc22cbe700a343ff8dbc9e5e04bc6b74"
+checksum = "f690706b5db081dccea6206d7f6d594bb9895599abea9d1a0539f13888781ae8"
 dependencies = [
  "bon",
  "caseless",
@@ -301,7 +301,7 @@ dependencies = [
 
 [[package]]
 name = "confluence-updater"
-version = "2.1.1"
+version = "2.2.0"
 dependencies = [
  "clap",
  "comrak",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "confluence-updater"
-version = "2.1.1"
+version = "2.2.0"
 edition = "2021"
 description = "Render Markdown files and push them to Confluence Cloud pages."
 authors = ["Patrick Kerwood <patrick@kerwood.dk>"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_yml = "0.0.12"
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
-comrak = "0.35"
+comrak = "0.38"
 sha2 = "0.10.8"
 hex = "0.4.3"
 normalize-path = "0.2.1"

--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ INFO No changes to page, skipping. id="729133252" title="Grafana Install Guide [
 
 ### Command-Line Options
 ```sh
-Usage: confluence-updater [OPTIONS] --user <USER> --secret <SECRET>
+Usage: confluence-updater [OPTIONS] --user <USER> --secret <SECRET> --fqdn <FQDN>
 
 Options:
-  -u, --user <USER>                Confluence login user [env: CU_USER=]
-  -s, --secret <SECRET>            API token [env: CU_SECRET=]
-      --fqdn <FQDN>                Atlassian Cloud domain [env: CU_FQDN=]
-  -c, --config-path <CONFIG_PATH>  Config file path [default: ./confluence-updater.yaml]
-  -l, --label <label>              Add labels to pages (repeatable)
-      --log-level <LOG_LEVEL>      Log level [default: info] [trace, debug, info, warn, error]
-  -h, --help                       Show help
-  -V, --version                    Show version
+  -u, --user <USER>                Confluence user to login with [env: CU_USER=]
+  -s, --secret <SECRET>            The token/secret to use. https://id.atlassian.com/manage-profile/security/api-tokens [env: CU_SECRET=]
+      --fqdn <FQDN>                The fully qualified domain name of your Atlassian Cloud. [env: CU_FQDN=]
+  -c, --config-path <CONFIG_PATH>  The path to the config file. [env: CU_CONFIG_PATH=] [default: ./confluence-updater.yaml]
+  -l, --label <label>              Add a label to all updating pages. Can be used multiple times.
+      --log-level <LOG_LEVEL>      Log Level. [env: CU_LOG_LEVEL=] [default: info] [possible values: trace, debug, info, warn, error]
+  -h, --help                       Print help
+  -V, --version                    Print version
 ```
 
 ## Features
@@ -68,6 +68,7 @@ The following elements are included in the SHA, meaning any changes to them will
 - Override title.
 - Superscript header.
 - Labels.
+- Read Only boolean
 
 ### Link Replacement
 Convert relative Markdown file links to Confluence page links using `pid:<page-id>`:
@@ -77,8 +78,16 @@ Convert relative Markdown file links to Confluence page links using `pid:<page-i
 ```
 
 ### Read-Only
-Restrict editing to the token owner by setting `readOnly` at the root or page level:
+If the `readOnly` property is **not** set at the global and page level configuration, Confluence Updater will not
+modify any existing page restrictions. This allows page restrictions to be set manually within Confluence without
+being overwritten by Confluence Updater.
 
+- Setting `readOnly: true` grants read-only access to everyone except the access token owner, who will retain write permissions.
+- Setting `readOnly: false` removes all user restrictions, effectively making the page editable by anyone in the Confluence space.
+
+Changing this setting will affect the `sha` label and trigger a page update.
+
+#### Example
 ```yaml
 readOnly: true
 pages:
@@ -158,6 +167,12 @@ A GitHub Action is available: [Confluence Updater Action](https://github.com/Ker
 ```
 
 ## Release Notes
+
+### v2.2.0
+- Added support for removing page restrictions by setting `readOnly: false`. See [Read Only](#read-only)
+- Added support for preserving existing page restrictions by omitting the `readOnly` property entirely. See [Read Only](#read-only)
+- Added validation for `fqdn`, `user`, and `secret` arguments to ensure values are **not** quoted, with clear error messages for invalid input.
+- Changed log level env name from `LOG_LEVEL` to `CU_LOG_LEVEL`.
 
 ### v2.1.1
 - Changed the `pa-token:xxx` and `page-sha:xxx` labels to use supported characters. (`pa-token/xxx`, `page-sha/xxx`)

--- a/confluence-updater.yaml
+++ b/confluence-updater.yaml
@@ -1,11 +1,11 @@
 superscriptHeader: This page is sourced from [kerwood/confluence-updater](https://github.com/Kerwood/confluence-updater) # Optional
-readOnly: true # Default. Optional
+# readOnly: false # Optional. If omitted Confluence Updater will not update page restrictions.
 pages:
   - filePath: ./path/to/markdown-1.md
     pageId: 353468432
     overrideTitle: Some Other Title # Optional
     superscriptHeader: Some other superscript header # Optional. This will override the global superscriptHeader property.
-    readOnly: false # Optional. This will override the global readOnly property.
+    readOnly: true # Optional. This will override the global readOnly property.
     labels: # Optional
       - ci/cd 
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,6 +114,14 @@ impl PageConfig {
         content.push_str(self.override_title.as_ref().unwrap_or(&"".to_string()));
         content.push_str(self.superscript_header.as_ref().unwrap_or(&"".to_string()));
 
+        let restrictions = match self.read_only {
+            Some(true) => "true",
+            Some(false) => "false",
+            None => "none",
+        };
+
+        content.push_str(restrictions);
+
         if let Some(vec) = &self.labels {
             content.push_str(&vec.join(""));
         }
@@ -167,7 +175,7 @@ impl Config {
 
             // Set default read_only to true or overwrite read_only if it's set globally and not explicitly on the page.
             page_config.read_only = match (config_file.read_only, page_config.read_only) {
-                (None, None) => Some(false),
+                (None, None) => None,
                 (_, Some(page)) => Some(page),
                 (Some(config), None) => Some(config),
             };

--- a/src/config.rs
+++ b/src/config.rs
@@ -167,7 +167,7 @@ impl Config {
 
             // Set default read_only to true or overwrite read_only if it's set globally and not explicitly on the page.
             page_config.read_only = match (config_file.read_only, page_config.read_only) {
-                (None, None) => Some(true),
+                (None, None) => Some(false),
                 (_, Some(page)) => Some(page),
                 (Some(config), None) => Some(config),
             };

--- a/src/confluence/restriction.rs
+++ b/src/confluence/restriction.rs
@@ -25,7 +25,7 @@ struct User {
 }
 
 impl Restriction {
-    pub fn new(account_id: &str) -> Self {
+    pub fn read_only(account_id: &str) -> Self {
         Self {
             results: vec![Result {
                 operation: "update".to_string(),
@@ -35,6 +35,15 @@ impl Restriction {
                         account_id: account_id.to_string(),
                     }],
                 },
+            }],
+        }
+    }
+
+    pub fn no_restrictions() -> Self {
+        Self {
+            results: vec![Result {
+                operation: "update".to_string(),
+                restrictions: Restrictions { user: vec![] },
             }],
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,13 @@ struct CommandArgs {
     )]
     labels: Vec<String>,
 
-    #[arg(long, env, default_value = "info", help = "Log Level.", global = true)]
+    #[arg(
+        long,
+        env = "CU_LOG_LEVEL",
+        default_value = "info",
+        help = "Log Level.",
+        global = true
+    )]
     log_level: LogLevel,
 }
 


### PR DESCRIPTION
- Added support for removing page restrictions by setting `readOnly: false`. See [Read Only](#read-only)
- Added support for preserving existing page restrictions by omitting the `readOnly` property entirely. See [Read Only](#read-only)
- Added validation for `fqdn`, `user`, and `secret` arguments to ensure values are **not** quoted, with clear error messages for invalid input.
- Changed log level env name from `LOG_LEVEL` to `CU_LOG_LEVEL`.
