### PR TITLE
Dockerfile to be used in ci pipelines

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine:latest
+
+# Install curl
+RUN apk add --no-cache curl
+
+WORKDIR /app
+
+# Download and make the updater executable
+RUN curl -L https://github.com/Kerwood/confluence-updater/releases/latest/download/confluence-updater-x86_64-unknown-linux-musl -o /usr/local/bin/confluence-updater && \
+    chmod +x /usr/local/bin/confluence-updater
+
+# CMD
+CMD ["/usr/local/bin/confluence-updater"]


### PR DESCRIPTION
Not sure if this is needed. but this is what we use for our ci pipelines.

This method pull down the binary instead of a pure build. saves time.